### PR TITLE
Issue84

### DIFF
--- a/.github/workflows/macos_build_release.yml
+++ b/.github/workflows/macos_build_release.yml
@@ -1,15 +1,8 @@
-name: Ubuntu Build
+name: macOS Build
 
 on:
-  pull_request:
-    branches:
-      - master
-      - develop
-
   release:
-    types:
-      - published
-      - prereleased
+    types: [published]
 
 jobs:
   build:
@@ -17,8 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-18.04', 'ubuntu-20.04']
-        qt_version: ['5.12.6', '5.12.9']
+        os: ['macos-latest']
+        qt_version: ['5.15.2']
 
     steps:
     - name: Install Python 3.7 version
@@ -33,11 +26,6 @@ jobs:
         version: ${{ matrix.qt_version }}
         target: desktop
 
-    - name: Install Libraries
-      run: |
-        sudo apt-get update
-        sudo apt-get install build-essential libpulse-dev libgl1-mesa-dev
-
     - name: Checkout
       uses: actions/checkout@v2
 
@@ -45,16 +33,11 @@ jobs:
       run: |
         git submodule update --init --recursive
 
-    - name: Download CMake 3.16.2
-      run: |
-        wget https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2-Linux-x86_64.tar.gz
-        tar xvfz cmake-3.16.2-Linux-x86_64.tar.gz
-
     - name: Configure & Build
       run: |
         mkdir build
         cd build/
-        ../cmake-3.16.2-Linux-x86_64/bin/cmake -DCMAKE_PREFIX_PATH=${Qt5_Dir} -DCMAKE_BUILD_TYPE=Release ../
+        cmake -DCMAKE_PREFIX_PATH="${Qt5_Dir}" -DCMAKE_BUILD_TYPE=Release ../
         make -j
 
     - name: Unit Tests
@@ -63,9 +46,9 @@ jobs:
 
     - name: Deploy
       run: |
-        cd build/
-        mv gui/dancebotsEditor dancebots-editor
-        tar -zcvf dancebots-editor-ubuntu.tar.gz dancebots-editor
+        cd gui/mac_os_rc/
+        sh deploy.sh ../../build/ "${Qt5_Dir}/bin/" ../
+        mv ../../build/Dancebots\ Editor.dmg ../../build/dancebots-editor-darwin.dmg
 
     - name: Upload Release Asset
       id: upload-release-asset
@@ -75,7 +58,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets{?name,label}"
-        asset_path: build/dancebots-editor-ubuntu.tar.gz
-        asset_name: dancebots-editor-ubuntu.tar.gz
-        asset_content_type: application/zip
+        asset_path: build/dancebots-editor-darwin.dmg
+        asset_name: dancebots-editor-darwin.dmg
+        asset_content_type: application/x-apple-diskimage
 

--- a/.github/workflows/macos_build_release.yml
+++ b/.github/workflows/macos_build_release.yml
@@ -1,4 +1,4 @@
-name: macOS Build
+name: macOS Build Release
 
 on:
   release:

--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -1,4 +1,4 @@
-name: macOS Build
+name: macOS Build Test
 
 on: [pull_request]
 

--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -1,15 +1,6 @@
 name: macOS Build
 
-on:
-  pull_request:
-    branches:
-      - master
-      - develop
-
-  release:
-    types:
-      - published
-      - prereleased
+on: [pull_request]
 
 jobs:
   build:
@@ -18,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: ['macos-10.15', 'macos-11.0']
-        qt_version: ['5.12.6', '5.12.9']
+        qt_version: ['5.12.6', '5.12.9', '5.15.2']
 
     steps:
     - name: Install Python 3.7 version
@@ -51,21 +42,9 @@ jobs:
       run: |
         sh scripts/run_tests.sh build
 
-    - name: Deploy
+    - name: Test Deploy Script
       run: |
         cd gui/mac_os_rc/
         sh deploy.sh ../../build/ "${Qt5_Dir}/bin/" ../
         mv ../../build/Dancebots\ Editor.dmg ../../build/dancebots-editor-darwin.dmg
-
-    - name: Upload Release Asset
-      id: upload-release-asset
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets{?name,label}"
-        asset_path: build/dancebots-editor-darwin.dmg
-        asset_name: dancebots-editor-darwin.dmg
-        asset_content_type: application/x-apple-diskimage
 

--- a/.github/workflows/ubuntu_build_test.yml
+++ b/.github/workflows/ubuntu_build_test.yml
@@ -1,4 +1,4 @@
-name: Ubuntu Build
+name: Ubuntu Build Test
 
 on: [pull_request]
 

--- a/.github/workflows/ubuntu_build_test.yml
+++ b/.github/workflows/ubuntu_build_test.yml
@@ -1,0 +1,72 @@
+name: Ubuntu Build
+
+on: [pull_request]
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }} with Qt ${{ matrix.qt_version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['ubuntu-18.04', 'ubuntu-20.04']
+        qt_version: ['5.12.6', '5.12.9', '5.15.2']
+
+    steps:
+    - name: Install Python 3.7 version
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+        architecture: 'x64'
+
+    - name: Install Qt ${{ matrix.qt_version }}
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: ${{ matrix.qt_version }}
+        target: desktop
+
+    - name: Install Libraries
+      run: |
+        sudo apt-get update
+        sudo apt-get install build-essential libpulse-dev libgl1-mesa-dev
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Update git submodules
+      run: |
+        git submodule update --init --recursive
+
+    - name: Download CMake 3.16.2
+      run: |
+        wget https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2-Linux-x86_64.tar.gz
+        tar xvfz cmake-3.16.2-Linux-x86_64.tar.gz
+
+    - name: Configure & Build
+      run: |
+        mkdir build
+        cd build/
+        ../cmake-3.16.2-Linux-x86_64/bin/cmake -DCMAKE_PREFIX_PATH=${Qt5_Dir} -DCMAKE_BUILD_TYPE=Release ../
+        make -j
+
+    - name: Unit Tests
+      run: |
+        sh scripts/run_tests.sh build
+
+    - name: Test Deploy Script
+      run: |
+        cd build/
+        mv gui/dancebotsEditor dancebots-editor
+        tar -zcvf dancebots-editor-ubuntu.tar.gz dancebots-editor
+
+    # - name: Upload Release Asset
+    #   id: upload-release-asset
+    #   if: startsWith(github.ref, 'refs/tags/')
+    #   uses: actions/upload-release-asset@v1
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     upload_url: "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets{?name,label}"
+    #     asset_path: build/dancebots-editor-ubuntu.tar.gz
+    #     asset_name: dancebots-editor-ubuntu.tar.gz
+    #     asset_content_type: application/zip
+

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -1,4 +1,4 @@
-name: Windows Build
+name: Windows Build Test
 
 on: [pull_request]
 

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -1,15 +1,6 @@
 name: Windows Build
 
-on:
-  pull_request:
-    branches:
-      - master
-      - develop
-
-  release:
-    types:
-      - published
-      - prereleased
+on: [pull_request]
 
 jobs:
   build:
@@ -18,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: ['windows-2019']
-        qt_version: ['5.12.6', '5.12.9']
+        qt_version: ['5.12.6', '5.12.9', '5.15.2']
 
     steps:
     - name: Install Python 3.7 version

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![Windows Build](https://github.com/philippReist/DanceBotsEditor/workflows/Windows%20Build/badge.svg)
-![macOS Build](https://github.com/philippReist/DanceBotsEditor/workflows/macOS%20Build/badge.svg)
-![Ubuntu Build](https://github.com/philippReist/DanceBotsEditor/workflows/Ubuntu%20Build/badge.svg)
+![Windows Build](https://github.com/philippReist/DanceBotsEditor/actions/workflows/windows_build_test.yml/badge.svg)
+![macOS Build](https://github.com/philippReist/DanceBotsEditor/actions/workflows/macos_build_test.yml/badge.svg)
+![Ubuntu Build](https://github.com/philippReist/DanceBotsEditor/actions/workflows/ubuntu_build_test.yml/badge.svg)
 
 # Introduction
 The Dancebots Editor allows creating choreographies for Dancebots, which are small and inexpensive differential drive robots that can move and blink their eight LEDs. They are designed to be built from scratch by children, see [here](https://www.dancebots.ch/) for more information.


### PR DESCRIPTION
Resolves #84 

After merging this PR into the `develop` branch:
- Build tests will run on _any_ pull-request
- A binary will be generated and automatically added to _any_ GitHub release (including pre-releases).

Build tests have also be updated to include QT's latest LTS version 5.15.2.

Notes: 
- Currently, only macOS binaries are supported. Window binaries can be added if/when there's a script that that can create a Windows package/installer.
- Binaries are generated using the latest OS and latest QT LTS version.